### PR TITLE
Add EN thread: Every meter you drive is live LLM inference—your speed is limited only by your API quota, and you’re literally burning tokens as fast as you race.

### DIFF
--- a/src/pages/en/blog/thread-en-2025-05-25-26334081.md
+++ b/src/pages/en/blog/thread-en-2025-05-25-26334081.md
@@ -1,0 +1,21 @@
+---
+layout: ../../../layouts/PostLayout.astro
+title: "Every meter you drive is live LLM inference—your speed is limited only by your API quota, and you’re literally burning tokens as fast as you race."
+description: "Every meter you drive is live LLM inference—your speed is limited only by your API quota, and you’re literally burning tokens as fast as you race. https:/…"
+pubDate: 2025-05-25
+lang: en
+messageCount: 1
+previewVideos:
+  - "/videos/thread-en-2025-05-25-26334081/001.mov"
+singleMessageHtml: |
+  Every meter you drive is live LLM inference—your speed is limited only by your API quota, and you’re literally burning tokens as fast as you race.
+  
+  <a href="https://github.com/vetertann/token_racer" target="_blank" rel="noopener noreferrer">https://github.com/vetertann/token_racer</a>
+---
+
+<figure>
+  <video controls playsinline preload="metadata" src="/videos/thread-en-2025-05-25-26334081/001.mov"></video>
+  <figcaption>Every meter you drive is live LLM inference—your speed is limited only by your API quota, and you’re literally burning tokens as fast as you race.
+
+<a href="https://github.com/vetertann/token_racer" target="_blank" rel="noopener noreferrer">https://github.com/vetertann/token_racer</a></figcaption>
+</figure>


### PR DESCRIPTION
## Summary
- Adds one new EN thread imported from Telegram
- Preserves message order and media sequencing
- Source file: `src/pages/en/blog/thread-en-2025-05-25-26334081.md`